### PR TITLE
added missing -m and missing --logger_project

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -24,7 +24,7 @@ stages:
     - data/graph/
   train:
     cmd:
-    - sbatch -W ${slurm-defaults} machines/slurm.neural-lam.sh --config_path ./data/config.yaml --logger ${logger} ${logger_project} ${baseline-defaults}
+    - sbatch -W ${slurm-defaults} machines/slurm.neural-lam.sh --config_path ./data/config.yaml --logger ${logger} --logger_project ${logger_project} ${baseline-defaults}
     deps:
     - version.mllam.txt
     - data/graph/

--- a/machines/slurm.neural-lam.sh
+++ b/machines/slurm.neural-lam.sh
@@ -24,4 +24,4 @@ OMP_NUM_THREADS=56
 OMPI_MCA_coll_hcoll_enable=0
 set +a
 
-srun -ul python neural_lam.train_model "$@"
+srun -ul python -m neural_lam.train_model "$@"


### PR DESCRIPTION
Tried to run the new baseline, and it seems a -m was missing in front of neural_lam.train_model in slurm.neural-lam.sh

And in dvc.yaml, --logger_project was missing in front of ${logger_project}.


