### PR TITLE
Adding common cache with symlinks

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,8 @@
 [core]
     remote = localshare
+[cache]
+    dir = /dcai/projects/cu_0003/dvc_shared_cache
+    shared = group
+    type = symlink
 ['remote "localshare"']
     url = /dcai/projects/cu_0003/dvc/


### PR DESCRIPTION
This PR adds a shared DVC cache that should allow us to share and link datastores.