### PR TITLE
fixed logger-project argument: - instead of  _

### DIFF
--- a/dvc.yaml
+++ b/dvc.yaml
@@ -24,7 +24,7 @@ stages:
     - data/graph/
   train:
     cmd:
-    - sbatch -W ${slurm-defaults} machines/slurm.neural-lam.sh --config_path ./data/config.yaml --logger ${logger} --logger_project ${logger_project} ${baseline-defaults}
+    - sbatch -W ${slurm-defaults} machines/slurm.neural-lam.sh --config_path ./data/config.yaml --logger ${logger} --logger-project ${logger-project} ${baseline-defaults}
     deps:
     - version.mllam.txt
     - data/graph/
@@ -35,7 +35,7 @@ stages:
   evaluate:
     cmd:
     - sbatch -W ${slurm-eval} machines/slurm.neural-lam.sh --config_path ./data/config.yaml --eval val --load
-      ./saved_models/*/last.ckpt --logger ${logger} --logger_project ${logger_project} ${baseline-eval}
+      ./saved_models/*/last.ckpt --logger ${logger} --logger-project ${logger-project} ${baseline-eval}
     deps:
     - version.mllam.txt
     - data/graph/

--- a/params.yaml
+++ b/params.yaml
@@ -13,7 +13,7 @@
 # the name of the "experiment" on mlflow that your run(s) will be grouped under
 # change this to something that describes what you'll be working on (for
 # example what the parameter study is about)
-logger_project: A-baseline
+logger-project: &logger-project A-baseline
 
 graph-defaults:
   levels: 4
@@ -45,7 +45,7 @@ baseline-eval:
   num_nodes: &num_nodes_eval 1     # and overwrite the num_nodes parameter to make it evaluation stage specific
 
 slurm-defaults: &slurm-defaults    # SLURM directives, which gets passed to sbatch
-  job-name: NeuralLam
+  job-name: *logger-project
   time: 1-00:00:00
   nodes: *num_nodes                # set in baseline-defaults section above and referenced here via alias
   ntasks-per-node: 8


### PR DESCRIPTION
This PR fixes a bug where logger_project was supplied to the neural lam cli instead of logger-project