### PR TITLE
Added -K1 flag

### DIFF
--- a/machines/slurm.mllam-data-prep.sh
+++ b/machines/slurm.mllam-data-prep.sh
@@ -40,7 +40,7 @@ OUTPUT_PATH=$3
 
 python machines/log_system_metrics_during_dataprep.py --config_path=${CONFIG_PATH} --dataset_output_path=${OUTPUT_PATH} & LOGGER_PID=$! && disown
 
-srun -ul python -m mllam_data_prep "$@"
+srun -ul -K1 python -m mllam_data_prep "$@"
 
 # kill the logger process, ensuring it has stopped before exiting
 while ps -p $LOGGER_PID > /dev/null; kill $LOGGER_PID; do sleep 1; done

--- a/machines/slurm.neural-lam.sh
+++ b/machines/slurm.neural-lam.sh
@@ -35,4 +35,4 @@ echo "Using venv in ${MLLAM_VENV_PATH}"
 source ${MLLAM_VENV_PATH}/bin/activate
 
 # pass all arguments to the python script
-srun -ul python -m neural_lam.train_model "$@"
+srun -ul -K1 python -m neural_lam.train_model "$@"


### PR DESCRIPTION
From the SLURM config the default for KillOnBadExit is 0. The -K1 flag sets KillOnBadExit to 1, which makes the slurn job be killed on bad exits.