### PR TITLE
set logger run name with DVC experiment name

### DIFF
--- a/machines/slurm.neural-lam.sh
+++ b/machines/slurm.neural-lam.sh
@@ -35,4 +35,4 @@ echo "Using venv in ${MLLAM_VENV_PATH}"
 source ${MLLAM_VENV_PATH}/bin/activate
 
 # pass all arguments to the python script
-srun -ul python -m neural_lam.train_model "$@"
+srun -ul python -m neural_lam.train_model --logger_run_name $DVC_EXP_NAME "$@"


### PR DESCRIPTION
This PR communicates the DVC experiment name to MLflow via neural-lam and the soon available `logger_run_name` command line argument.

It will improve and simplify the traceability across DVC and MLflow.