### PR TITLE
remove sourcing of secrets

### DIFF
--- a/machines/slurm.neural-lam.sh
+++ b/machines/slurm.neural-lam.sh
@@ -13,7 +13,6 @@ export CARTOPY_DATA_DIR=/dcai/projects01/cu_0003/data/cartopy_features
 export MLFLOW_TRACKING_URI="https://mlflow.dmi.dcs.dcai.dk" #sqlite:///mlflow.db #
 export MLFLOW_TRACKING_INSECURE_TLS=true
 
-source machines/secrets.sh
 source machines/environment.sh
 
 set -a


### PR DESCRIPTION
secrets are not versioned and therefore not available on temp/queue. secrets should be sourced from ~/.bashrc